### PR TITLE
Add tasks.txt to Dockerfile and deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,4 +47,5 @@ jobs:
             
             docker run -d --name codefrost-discord-motivation-bot \
             --env-file .env \
+            -v ~/tasks.txt:/app/tasks.txt \
             atomrem/codefrost-discord-motivation-bot:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,8 @@ RUN yarn install --frozen-lockfile
 # Copy local code to the container image.
 COPY . ./
 
+# Copy tasks.txt file
+COPY tasks.txt ./
+
 # Start the application
 CMD ["yarn", "start"]


### PR DESCRIPTION
In this commit, we added a 'tasks.txt' file to the Docker image build by adding it to the Dockerfile. Additionally, we updated the GitHub Actions deployment script to bind mount this 'tasks.txt' file from the host to the Docker container during deployment.